### PR TITLE
Implement Code Splitter for LLMs to understand the codebase deeper (#10)

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@google/generative-ai": "^0.21.0",
     "axios": "^1.7.9",
+    "langchain": "^0.3.7",
     "next": "15.1.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/src/agent/document-splitter/code-splitter.js
+++ b/src/agent/document-splitter/code-splitter.js
@@ -1,0 +1,64 @@
+import { RecursiveCharacterTextSplitter } from '@langchain/textsplitters';
+
+/**
+ * Splitting code into chunks into Langchain document depending on file extension.
+ */
+export default class CodeSplitter {
+    /**
+     * Constructor for CodeSplitter.
+     * @param {number} chunkSize - The size of each chunk.
+     * @param {number} chunkOverlap - The number of overlapping characters between chunks.
+     */
+    constructor(chunkSize, chunkOverlap) {
+        this.chunkSize = chunkSize;
+        this.chunkOverlap = chunkOverlap;
+    }
+
+    /**
+     * Retrieves the programming language associated with a given file extension.
+     * @param {string} extension - The file extension excluding the dot (e.g., 'js', 'py').
+     * @returns {Language | null} - The corresponding Language enum or null (if not supported).
+     */
+    #getLanguageFromExtension(extension) {
+        let extensionToLanguageMap = {
+            'py': 'python',
+            'js': 'js',
+            'jsx': 'js',
+            'ts': 'js',
+            'tsx': 'js',
+            'go': 'go',
+            'rb': 'ruby',
+            'rs': 'rust',
+            'php': 'php',
+            'cpp': 'cpp',
+            'cc': 'cpp',
+            'cxx': 'cpp',
+            'hpp': 'cpp',
+            'hxx': 'cpp',
+            'h': 'cpp',
+        };
+        return extensionToLanguageMap[extension.toLowerCase()] || null;
+    }
+
+    /**
+     * Splits the provided code into chunks based on the file extension.
+     * @param {string} fileExtension - The file extension indicating the programming language.
+     * @param {string} code - The code content to be split.
+     * @returns {Promise<Array<Document>> | null}  - A promise that resolves to an array of document chunks.
+     */
+    async splitCode(fileExtension, code) {
+        const language = this.#getLanguageFromExtension(fileExtension);
+        if (!language) {
+            return null;
+        }
+        
+
+        const splitter = RecursiveCharacterTextSplitter.fromLanguage(language, {
+            chunkSize: this.chunkSize,
+            chunkOverlap: this.chunkOverlap,
+        });
+
+        const documents = await splitter.createDocuments([code]);
+        return documents;
+    }
+}

--- a/src/test/agent/document-splitter/code-splitter.test.js
+++ b/src/test/agent/document-splitter/code-splitter.test.js
@@ -1,0 +1,35 @@
+import CodeSplitter from '@/agent/document-splitter/code-splitter';
+
+describe('CodeSplitter', () => {
+  let codeSplitter;
+
+  beforeEach(() => {
+    codeSplitter = new CodeSplitter(1000, 100);
+  });
+
+  test('should split JavaScript code into chunks', async () => {
+    const code = `
+      function add(a, b) {
+        return a + b;
+      }
+    `;
+    const fileExtension = 'js';
+
+    const documents = await codeSplitter.splitCode(fileExtension, code);
+
+    expect(documents).toHaveLength(1);
+    expect(documents[0].pageContent).toContain('function add(a, b)');
+  });
+
+  test('should return null for unsupported file extensions', async () => {
+    const code = `
+      def add(a, b):
+          return a + b
+    `;
+    const fileExtension = 'unsupported';
+
+    const documents = await codeSplitter.splitCode(fileExtension, code);
+
+    expect(documents).toBeNull();
+  });
+});


### PR DESCRIPTION
Implement Code Splitter for Allowing LLMs to understand the codebase deeper depending on the type of programming language [Langchain Code Splitter](https://js.langchain.com/v0.1/docs/modules/data_connection/document_transformers/code_splitter/) Refer #10 for more