### PR TITLE
Change the example main page searchbar to my project name (#63)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -42,7 +42,7 @@ export default function GitHubSearch() {
                 <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
                 <Input
                   id="search"
-                  placeholder="Enter GitHub URL or owner/repo (e.g., vercel/next.js)"
+                  placeholder="Enter GitHub URL or owner/repo (e.g., daeisbae/open-repo-wiki)"
                   value={searchValue}
                   onChange={(e) => setSearchValue(e.target.value)}
                   className="pl-9 py-6"


### PR DESCRIPTION
# Problem
- Change the example main page searchbar to my project name (#63) -> vercel/nextjs -> daeisbae/open-repo-wiki