### PR TITLE
Implement collapsible heading for summarization page (#125)

### DIFF
--- a/src/app/[ownerSlug]/[repoSlug]/formatter.ts
+++ b/src/app/[ownerSlug]/[repoSlug]/formatter.ts
@@ -1,4 +1,4 @@
-
+import { FileData } from '@/db/models/file'
 import { FullFolder, FullRepository } from '@/service/get-db'
 
 export function formatToMarkdownSections(fullRepo: FullRepository): string[] {
@@ -8,10 +8,9 @@ export function formatToMarkdownSections(fullRepo: FullRepository): string[] {
 
     const url = `https://github.com/${repo.owner}/${repo.repo}/blob/${branches?.last_commit_sha}`
 
-    // We'll accumulate our markdown sections in an array
     const sections: string[] = []
     if (folders.length > 0) {
-        recursiveFolderToMarkdownSections(folders[0], url, '#', sections)
+        recursiveFolderToMarkdownSections(folders[0], url, 1, sections)
     }
 
     return sections
@@ -20,38 +19,39 @@ export function formatToMarkdownSections(fullRepo: FullRepository): string[] {
 function recursiveFolderToMarkdownSections(
     folder: FullFolder,
     url: string,
-    subfolderHeading: string,
+    subfolderHeadingNo: number,
     sections: string[]
 ) {
-    let markdown = `${subfolderHeading} ${folder.usage}\n`
+    let markdown = `<CollapsibleHeader heading="${folder.usage}" level={${subfolderHeadingNo}} open={true}>\n`
     markdown += `---\n`
     markdown += folder.path
         ? `- Reference: [\`${folder.path}\`](${url}/${folder.path}) \n`
         : ''
     markdown += `\n${folder.ai_summary}\n`
 
-    // folder.files.filter(isNotMarkdownFile).forEach((file) => {
-    //     markdown += `###### ${file.usage}\n`
-    //     markdown += `---\n`
-    //     markdown += file.name
-    //         ? `- Reference: [\`${file.name}\`](${url}/${file.name}) \n`
-    //         : ''
-    //     markdown += `\n${file.ai_summary}\n`
-    // })
+    folder.files.filter(isNotMarkdownFile).forEach((file) => {
+        markdown += `<CollapsibleHeader heading="${file.usage}" level={6}>\n`
+        markdown += `---\n`
+        markdown += file.name
+            ? `- Reference: [\`${file.name}\`](${url}/${file.name}) \n`
+            : ''
+        markdown += `\n${file.ai_summary}\n`
+        markdown += `</CollapsibleHeader>\n`
+    })
+    markdown += `</CollapsibleHeader>\n`
 
-    // Each "folder section" is one chunk of markdown
     sections.push(markdown)
 
     folder.subfolders.forEach((subfolder) => {
         recursiveFolderToMarkdownSections(
             subfolder,
             url,
-            subfolderHeading.length >= 5 ? subfolderHeading : subfolderHeading + '#',
+            subfolderHeadingNo >= 5 ? subfolderHeadingNo : ++subfolderHeadingNo,
             sections
         )
     })
 }
 
-// function isNotMarkdownFile(file: FileData): boolean {
-//     return !file.name.includes('.md')
-// }
+function isNotMarkdownFile(file: FileData): boolean {
+    return !file.name.includes('.md')
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -14,17 +14,11 @@ body {
 
 :root {
   --heading-top-padding: 20px;
-  --h1-bottom-padding: 20px;
-}
-
-h1 + hr {
-  padding-bottom: 20px;
 }
 
 h1 {
   font-size: 32px;
   font-weight: bold;
-  padding-bottom: var(--h1-bottom-padding);
 }
 
 h2 {
@@ -53,14 +47,19 @@ h5 {
 
 h6 {
   padding-top: var(--heading-top-padding);
-  font-size: 20px;
+  font-size: 16px;
   font-weight: bold;
 }
 
 ul {
   list-style-type: disc;
   padding-left: 1em;
-  padding-top: 10px;
+  padding-top: 0;
+  padding-bottom: 10px;
+}
+
+hr {
+  padding-top: 0;
   padding-bottom: 10px;
 }
 
@@ -74,7 +73,6 @@ a > code {
 @media screen and (max-width: 768px) {
   h1 {
     font-size: 24px;
-    padding-bottom: 0;
   }
 
   h2 {
@@ -94,12 +92,15 @@ a > code {
   }
 
   h6 {
-    font-size: 18px;
+    font-size: 16px;
   }
 
   ul {
-    padding-top: 6px;
     padding-bottom:6px;
+  }
+
+  hr {
+    padding-bottom: 6px;
   }
 
   a > code {

--- a/src/components/CollapsibleHeader.tsx
+++ b/src/components/CollapsibleHeader.tsx
@@ -1,0 +1,45 @@
+'use client';
+import React, { useState, JSX } from 'react';
+
+interface CollapsibleHeaderProps {
+    heading: number;
+    children: React.ReactNode;
+    level: number;
+    open?: boolean;
+}
+
+export default function CollapsibleHeader({ heading, children, level, open = false } : CollapsibleHeaderProps): JSX.Element {
+  const [isOpen, setIsOpen] = useState(open);
+
+  const toggle = () => setIsOpen(!isOpen);
+
+  const HeadingTag = `h${level}`;
+
+  return (
+    <div>
+      <HeadingTag
+        onClick={toggle}
+        className='cursor-pointer flex items-center'
+      >
+        <span className={`ml-0 md:ml-1 text-sm ${isOpen ? 'rotate-90' : 'rotate-0'} transition-transform ${level < 6 ? 'mr-3' : 'mr-1'}`}>
+        <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        strokeWidth="2"
+                        stroke="currentColor"
+                        className="w-3 h-3"
+                    >
+                        <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            d="M9 5l7 7-7 7"
+                        />
+                    </svg>
+        </span>
+        {heading}
+      </HeadingTag>
+      {isOpen && <div className={`${heading < 6 ? 'ml-0 md:ml-2' : 'ml-5'}`}>{children}</div>}
+    </div>
+  );
+}

--- a/src/components/MarkdownContent.tsx
+++ b/src/components/MarkdownContent.tsx
@@ -2,6 +2,7 @@
 
 import { MDXRemote } from 'next-mdx-remote'
 import { serialize } from 'next-mdx-remote/serialize'
+import CollapsibleHeader from './CollapsibleHeader'
 import { useState, useEffect } from 'react'
 import React from 'react'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -27,7 +28,7 @@ export function MarkdownContent({ content }: MarkdownContentProps) {
 
     return (
         <div className="prose dark:prose-invert max-w-none">
-            <MDXRemote {...serializedContent} />
+            <MDXRemote {...serializedContent} components={{CollapsibleHeader}} />
         </div>
     )
 }


### PR DESCRIPTION
# Changes
- Implement collapsible heading for summarization page
<img width="1728" alt="Screenshot 2025-01-04 at 2 35 24 AM" src="https://github.com/user-attachments/assets/8d31144c-278a-4781-86b4-ac05339d6bad" />
