### PR TITLE
redirect when repo not found (#169)

### DIFF
--- a/src/app/[ownerSlug]/[repoSlug]/contents.tsx
+++ b/src/app/[ownerSlug]/[repoSlug]/contents.tsx
@@ -1,7 +1,6 @@
 import { RepoCard } from '@/components/RepoCard';
 import { MarkdownContent } from '@/components/MarkdownContent';
 import { formatToMarkdownSections } from '@/app/[ownerSlug]/[repoSlug]/formatter';
-import Loading from '@/app/[ownerSlug]/[repoSlug]/loading';
 import { notFound } from 'next/navigation';
 import { FetchRepoService } from '@/service/get-db';
 

--- a/src/app/[ownerSlug]/[repoSlug]/create-repo.tsx
+++ b/src/app/[ownerSlug]/[repoSlug]/create-repo.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { Link } from "next/navigation";
+
+interface CreateRepositoryProps {
+	owner: string;
+	repo: string;
+}
+
+export async function CreateRepository({ owner, repo }: CreateRepositoryProps) {
+	return (
+		<div className="flex flex-col items-center justify-center w-full h-full">
+			<h1 className="text-lg md:text-3xl mb-6 text-center">
+				The repository is not created yet
+			</h1>
+			<div className="bg-black hover:bg-slate-900 text-white py-4 px-6 rounded-md">
+				<Link
+					href={{
+						pathname: "/add/repositories",
+						query: { owner: owner, repo: repo },
+					}}
+				>
+					Create this repository
+				</Link>
+			</div>
+		</div>
+	);
+}

--- a/src/app/add/repositories/page.tsx
+++ b/src/app/add/repositories/page.tsx
@@ -1,8 +1,12 @@
 'use client';
 import React, { useState } from 'react';
+import { useSearchParams } from 'next/navigation'
 
 export default function Page() {
     const [response, setResponse] = useState(null);
+    const searchParams = useSearchParams()
+    const [owner, setOwner] = useState(searchParams.get('owner') || '');
+    const [repo, setRepo] = useState(searchParams.get('repo') || '');
   
     async function handleSubmit(event) {
       event.preventDefault();
@@ -27,6 +31,8 @@ export default function Page() {
         console.error(error);
         setResponse({ success: false, error: 'An error occurred while adding the repository.' });
       }
+      setOwner('')
+      setRepo('')
     }
   
 
@@ -40,6 +46,8 @@ export default function Page() {
             type="text"
             name="owner"
             placeholder="GitHub Owner"
+            value={owner}
+            onChange={(e) => {setOwner(e.target.value)}}
             required
           />
           <input
@@ -47,6 +55,8 @@ export default function Page() {
             type="text"
             name="repo"
             placeholder="Repository Name"
+            value={repo}
+            onChange={(e) => {setRepo(e.target.value)}}
             required
           />
         </div>


### PR DESCRIPTION
# Changes
- Redirect when repository is not found. Hence user do not need to manually visit `/add/repositories` to add the repository